### PR TITLE
Use alternatives for /etc/os-release

### DIFF
--- a/eshell-info-banner.el
+++ b/eshell-info-banner.el
@@ -297,9 +297,8 @@ the warning face with a battery level of 25% or less."
   "Read the operating system from the given RELEASE-FILE.
 
 If RELEASE-FILE is nil, use '/etc/os-release'."
-  (setq release-file (or release-file "/etc/os-release"))
   (with-temp-buffer
-    (insert-file-contents release-file)
+    (insert-file-contents (or release-file "/etc/os-release"))
     (goto-char (point-min))
     (re-search-forward "PRETTY_NAME=\"\\(.*\\)\"")
     (match-string 1)))

--- a/eshell-info-banner.el
+++ b/eshell-info-banner.el
@@ -298,14 +298,11 @@ the warning face with a battery level of 25% or less."
 
 If RELEASE-FILE is nil, use '/etc/os-release'."
   (setq release-file (or release-file "/etc/os-release"))
-  (replace-regexp-in-string
-   ".*\"\\(.+\\)\""
-   "\\1"
-   (car (-filter (lambda (line)
-                   (s-contains? "PRETTY_NAME" line))
-                 (s-lines (with-temp-buffer
-                            (insert-file-contents release-file)
-                            (buffer-string)))))))
+  (with-temp-buffer
+    (insert-file-contents release-file)
+    (goto-char (point-min))
+    (re-search-forward "PRETTY_NAME=\"\\(.*\\)\"")
+    (match-string 1)))
 
 (defun eshell-info-banner--get-os-information-from-hostnamectl ()
   "Read the operating system via hostnamectl."

--- a/eshell-info-banner.el
+++ b/eshell-info-banner.el
@@ -317,10 +317,11 @@ If RELEASE-FILE is nil, use '/etc/os-release'."
 
 (defun eshell-info-banner--get-os-information ()
   "Get operating system identifying information."
-  (or (ignore-errors (eshell-info-banner--get-os-information-from-hostnamectl))
-      (ignore-errors (eshell-info-banner--get-os-information-from-lsb-release))
-      (ignore-errors (eshell-info-banner--get-os-information-from-release))
-      "Unkown"))
+  (cond
+   ((executable-find "hostnamectl") (eshell-info-banner--get-os-information-from-hostnamectl))
+   ((executable-find "lsb_release") (eshell-info-banner--get-os-information-from-lsb-release))
+   ((file-exists-p "/etc/os-release") (eshell-info-banner--get-os-information-from-release-file))
+   (t "Unknown")))
 
                                         ; Public functions ;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
While `/etc/os-release` is usually available on Linux systems, it might be missing on distribution that don't follow that convention.

For those distributions, the commands `hostnamectl` (from systemd) and `lsb_release` might provide an alternative. Unfortunately, those commands might also be missing as well as `/etc/os-release`, so the newly introduced `eshell-info-banner--get-os-information` function falls back to the string "Unknown" (and should never fail).

I'm absolutely not sure about `ignore-errors` in `eshell-info-banner--get-os-information`. Something along
```lisp
(cond
  ((executable-find "hostnamectl") (...))
  ((executable-find "lsb_release) (...))
  ((file-exists-p "/etc/os-release") (...))
  ((executable-find "reg") (... windows handling ...)
  (t "Unknown"))
```
might be more suitable, but I believe that's best decided by you, @Phundrak  😄 

Fixes #1 and also simplifies the `PRETTY_NAME` matching slightly.