### PR TITLE
Use C locale for external processes to prevent parsing issues

### DIFF
--- a/eshell-info-banner.el
+++ b/eshell-info-banner.el
@@ -141,7 +141,7 @@ neither of these, an error will be thrown by the function."
   "Detect mounted partitions on the system.
 
 Return detected partitions as a list of structs."
-  (let ((partitions (split-string (shell-command-to-string "df -lH") (regexp-quote "\n") t)))
+  (let ((partitions (split-string (shell-command-to-string "LANG=C df -lH") (regexp-quote "\n") t)))
     (-keep (lambda (partition)
              (let* ((partition  (split-string partition " " t))
                     (filesystem (nth 0 partition))
@@ -348,7 +348,7 @@ If RELEASE-FILE is nil, use '/etc/os-release'."
          (memory        (-map (lambda (line)
                                 (s-split " " line t))
                               (s-split "\n"
-                                       (shell-command-to-string "free -b | tail -2")
+                                       (shell-command-to-string "LANG=C free -b | tail -2")
                                        t)))
          (ram           (nth 0 memory))
          (swap          (nth 1 memory))


### PR DESCRIPTION
Prevents wrong computation on my `de_DE.UTF-8` system:

```
================================================================================
OS......: Arch Linux                        Kernel.: Linux 5.11.16-arch1-1
Hostname: lemmy                             Uptime.: 1 day, 21 hours, 21 minutes
Battery.: [==============================================]                (100%)
Ram.....: [===================================================]   4.2G / 3.7G  (113%)
Swap....: [==============================================]      0 / 0     (  0%)
/.......: [==============================================]   201G / 243G  ( 87%)
/home...: [==============================================]   217G / 317G  ( 72%)
/b/EFI..: [==============================================]   852k / 1.1G  (  1%)
================================================================================
~/github/Phundrak/eshell-info-banner.el $ 
```

Root cause, missing space after (Memory/Speicher) prefix:
```
# free -b
              gesamt       benutzt     frei      gemns.  Puffer/Cache verfügbar
Speicher:16210317312  3955281920  4581228544   649596928  7673806848 11252981760
Swap:              0           0           0

# LANG=C free -b
               total        used        free      shared  buff/cache   available
Mem:     16210317312  3971899392  4553101312   660971520  7685316608 11224989696
Swap:              0           0           0


``` 
