### PR TITLE
Fix void-variable error: partitions

### DIFF
--- a/eshell-info-banner.el
+++ b/eshell-info-banner.el
@@ -512,6 +512,7 @@ If RELEASE-FILE is nil, use '/etc/os-release'."
          (kernel        (concat (s-trim (shell-command-to-string "uname -s"))
                                 " "
                                 (s-trim (shell-command-to-string "uname -r"))))
+         (partitions    (eshell-info-banner--get-mounted-partitions))
          (left-padding  (eshell-info-banner--get-longest-path partitions))
          (left-text     (max (length os)
                              (length hostname)))


### PR DESCRIPTION
Fixes this issue introduced by 763d459a9e5fb476017b91ec7ddfd3713d49a79c:

```
   Debugger entered--Lisp error: (void-variable partitions)
  (eshell-info-banner--get-longest-path partitions)
  (let* ((default-directory (if eshell-info-banner-tramp-aware default-directory "~")) (os (eshell-info-banner-$
  eshell-info-banner()
  (setq eshell-banner-message (eshell-info-banner))
  eshell-info-banner-update-banner()
  run-hooks(eshell-banner-load-hook)
  eshell-mode()
```