### PR TITLE
Add options to filter the partitions list

### DIFF
--- a/README.org
+++ b/README.org
@@ -109,6 +109,15 @@ A couple of variables can be edited by the user in order to configure
   set its value to ~("/dev" "zroot")~.
 
   Default value: ~("/dev")~
+- ~eshell-info-banner-filter-duplicate-partitions~ :: Try to filter
+  out duplicate partitions. Two partitions are considered duplicate if
+  they have the same size and amount of space used.
+
+  Default value: ~nil~
+- ~eshell-info-banner-exclude-partitions~ :: List of pattens to exclude
+  from the partition list.
+
+  Default value: ~nil~
 - ~eshell-info-banner-shorten-path-from~ :: Maximum length of the mount
   path of a partition before it gets abbreviated. Set it to ridiculous
   numbers in order to disable it (something like ~1000~ should be more


### PR DESCRIPTION
Here's how `eshell-info-banner` looks on one server I had to ssh into the day before:

![image](https://user-images.githubusercontent.com/21692287/180299310-edc3a3b3-042d-4560-ab0f-5940bb306abd.png)

Which isn't quite what I want to see. I've added a variable called `eshell-info-banner-filter-duplicate-partitions` to try to trim that list:

![image](https://user-images.githubusercontent.com/21692287/180297848-e6ff9ab6-e203-49af-ba7a-73413418ef27.png)

Another similar case is various snap partitions:

![image](https://user-images.githubusercontent.com/21692287/180297980-482fe4e5-a68f-47de-90c6-08865fb4dbb5.png)

I've added the `eshell-info-banner-exclude-partitions` variable to filter these out. Here's a regex I came up with for this case:

```lisp
(setq eshell-info-banner-exclude-partitions `(,(rx bos (? "/") "s" (? "n" (? "a" (? "p"))) "/")))
```

And the result:

![image](https://user-images.githubusercontent.com/21692287/180298910-26075e77-baf5-44ca-b351-0b7226b2eab1.png)

On my local machine I've set it to:
```lisp
(setq eshell-info-banner-exclude-partitions '("b/efi"))
```
Because I'm not really interested in how much space does the EFI partition have.